### PR TITLE
Disable editing for files inside Pods directory

### DIFF
--- a/Helmet/NSViewController+Helmet.m
+++ b/Helmet/NSViewController+Helmet.m
@@ -36,14 +36,14 @@ void * HLEditingTextViewKey = &HLEditingTextViewKey;
     @try {
         id editorDocument = [self valueForKey:@"_document"];
         id editorTextView = self.hl_EditingTextView;
-        
+
         if ([editorDocument isKindOfClass:NSClassFromString(@"IDESourceCodeDocument")] && [editorTextView isKindOfClass:[NSTextView class]]) {
             NSTextView *castTextView = (NSTextView *)editorTextView;
             NSURL *fileURL = [editorDocument valueForKeyPath:@"filePath.fileURL"];
             BOOL editable = [self filePathIsEditable:fileURL];
             castTextView.editable = editable;
         }
-        
+
     }
     @catch (NSException *exception) {
         NSLog(@"[HL] %@", exception);
@@ -52,9 +52,15 @@ void * HLEditingTextViewKey = &HLEditingTextViewKey;
 
 - (BOOL)filePathIsEditable:(NSURL *)filePath {
     NSString *absolutePath = [filePath relativePath];
+
     if ([absolutePath hasPrefix:@"/Applications/Xcode.app/"]) {
         return NO;
     }
+
+    if ([absolutePath rangeOfString:@"/Pods/"].location != NSNotFound) {
+        return NO;
+    }
+
     return YES;
 }
 


### PR DESCRIPTION
We use a lot of CocoaPods at work and it so happens that from time to time we have brain farts and start editing them directly in the project. To avoid this we were thinking about writing a plugin... and then we found Helmet. However Helmet does not support this, hence me making this pull request with the tiny change that we had to make.

Hope you like it.
