### PR TITLE
Don't rely on hardcoded application path.

### DIFF
--- a/Helmet/NSViewController+Helmet.m
+++ b/Helmet/NSViewController+Helmet.m
@@ -53,7 +53,9 @@ void * HLEditingTextViewKey = &HLEditingTextViewKey;
 - (BOOL)filePathIsEditable:(NSURL *)filePath {
     NSString *absolutePath = [filePath relativePath];
 
-    if ([absolutePath hasPrefix:@"/Applications/Xcode.app/"]) {
+    NSString *xcodeBundlePath = [[NSBundle mainBundle] bundlePath];
+
+    if ([absolutePath hasPrefix:xcodeBundlePath]) {
         return NO;
     }
 


### PR DESCRIPTION
Don't rely on Xcode being installed in exactly the same place on
everyone's computer. This will allow for anyone to install Xcode where
they see fit, while still having their Helmet on.

This fixes issue #3 
