### PR TITLE
Support for Xcode Version 6.2 (6C131e)

### DIFF
--- a/Helmet/Info.plist
+++ b/Helmet/Info.plist
@@ -26,6 +26,7 @@
 	<array>
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
+		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>


### PR DESCRIPTION
Add `DVTPlugInCompatibilityUUID` for Xcode Version 6.2 (6C131e)

I found no new problems running on 6.2
